### PR TITLE
Fix: Remove CNAME copying steps from CI/CD workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,8 +308,6 @@ jobs:
           ESLINT_NO_DEV_ERRORS: true
           TSC_COMPILE_ON_ERROR: true
           
-      - name: Copy CNAME file for staging
-        run: cp CNAME ./client/build/CNAME
       - name: Deploy to GitHub Pages (Staging)
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -372,8 +370,6 @@ jobs:
           ESLINT_NO_DEV_ERRORS: true
           TSC_COMPILE_ON_ERROR: true
           
-      - name: Copy CNAME file for production
-        run: cp CNAME ./client/build/CNAME
       - name: Deploy to GitHub Pages (Production)
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
This PR removes the CNAME file copying steps from the main CI/CD workflow to align with the approach used in the dedicated staging deployment workflow.

## Changes Made
- ✅ Removed CNAME copying step from staging deployment job
- ✅ Removed CNAME copying step from production deployment job
- ✅ Simplified deployment process by letting GitHub Pages handle domains automatically

## Why This Change?
1. **Consistency**: Aligns with the dedicated staging deployment workflow that already doesn't use CNAME copying
2. **Conflict Prevention**: Prevents potential domain conflicts with GitHub Pages' automatic handling
3. **Simplification**: Reduces complexity in the deployment process
4. **Best Practice**: GitHub Pages can handle domain configuration automatically when properly configured in repository settings

## Testing
- ✅ Workflow syntax is valid
- ✅ No breaking changes to deployment functionality
- ✅ Maintains all existing deployment capabilities

## Related Issues
- Addresses potential domain configuration conflicts
- Improves consistency across deployment workflows
- Part of ongoing CI/CD workflow improvements

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes are focused and minimal
- [x] No breaking changes introduced
- [x] Workflow syntax validated