### PR TITLE
Fix receipt email property inconsistency

### DIFF
--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -854,7 +854,7 @@ async function processStripePayment(
         studentId: enrollment.student._id.toString(),
       },
       description: `Payment for ${enrollment.course.title}`,
-      receiptEmail: enrollment.student.email,
+      receipt_email: enrollment.student.email,
     });
 
     // For demo purposes, we'll simulate a successful payment


### PR DESCRIPTION
```
## 🎯 Description
Fixes an inconsistency in the `processStripePayment` helper function by changing `receiptEmail` to `receipt_email` when creating a Stripe payment intent. This aligns with Stripe's API and the main `create-payment-intent` route, ensuring receipt emails are sent correctly.

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🚀 Performance improvement
- [ ] 🔒 Security fix

## 🔍 Changes Made
- Corrected the payment intent parameter from `receiptEmail` to `receipt_email` in `server/routes/payments.js` within the `processStripePayment` function.

## 📸 Screenshots (if applicable)
N/A

## 🧪 Testing
- [x] Tests pass locally
- [ ] Added new tests for new functionality
- [x] Existing tests still pass
- [x] Manual testing completed (verified receipt email functionality)

## 🚀 Deployment
- [x] No deployment changes needed
- [ ] Requires environment variable updates
- [ ] Requires database migration
- [ ] Requires dependency updates

## 📝 Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 📚 Additional Notes
This change ensures consistency with Stripe's API specification for payment intent creation, resolving a potential issue where receipt emails might not be sent due to an incorrect parameter name.

---

**Note**: This PR should only be created from the `develop` branch. PRs from other branches will be automatically rejected.
```